### PR TITLE
ci: Add initial Rust CI workflow

### DIFF
--- a/.github/workflows/cocl_basic_ci.yaml
+++ b/.github/workflows/cocl_basic_ci.yaml
@@ -1,0 +1,54 @@
+name: Code Quality
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'operator/**'
+      - 'crds/**'
+      - 'manifest-gen/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'operator/**'
+      - 'crds/**'
+      - 'manifest-gen/**'
+  create:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  basic_ci:
+    name: Rustfmt & Clippy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        target:
+          - x86_64-unknown-linux-gnu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          components: rustfmt, clippy
+          override: true
+
+      - name: Run cargo fmt check
+        run: cargo fmt --all --  --check
+
+      - name: Run rust lint check
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test --all


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to provide basic CI for the Rush codebase. The workflow performs the following checks on every push and pull request targeting the Ruse source directories (`operator`, `crds`, `manifest-gen`):
 - Validates code formatting using `cargo fmt`.
 - Lints for common issues using `cargo clippy`.
 - Executes the unit test suite with `cargo test`.